### PR TITLE
Feat: 펀드 데이터 수집 크롤러 추가 

### DIFF
--- a/fundguide/README.md
+++ b/fundguide/README.md
@@ -1,0 +1,58 @@
+## 펀드 크롤러
+
+### 데이터 수집 출처
+[펀드가이드-간편검색](https://www.fundguide.net/Fund/SimpleSearch)
+
+### 실행 방법 
+
+1. 필요 패키지 설치 
+```shell
+pip freeze > requirements.txt
+```
+
+2. fundlist.py 실행 
+- 기능 : 사이트 내의 펀드 목록을 csv파일, DB에 저장합니다.
+- 특이사항 : 아래 `sel_peers` 변수로 수집할 유형을 선택합니다.
+```python
+    sel_peers = {
+        # "국내주식형": "HS001|HSA01|HSAG1|HSAM1|HSAD1|HSAS1|HSAT1|HSP01|HSPP1|HSPX1|HSPS1|HSPO1",
+        # "국내혼합형": "HM001|HMA01|HMS01|HMB01|HMBM1|HMBA1|HMBH1",
+        # "국내채권형": "HB001|HBG01|HBC01|HBB01|HBBO1|HBBS1|HBH01",
+        # "해외주식형": "FS001|FSC01|FSCJ1|FSCC1|FSCI1|FSCV1|FSCB1|FSCR1|FSCO1|FSS01|FSSE1|FSSM1|FSSH1|FSSF1|FSSI1|FSSP1|FSSC1|FSSN1|FSSO1|FSR01|FSRG1|FSRD1|FSRM1|FSRU1|FSRE1|FSRN1|FSRS1|FSRP1|FSRX1|FSRA1|FSRI1|FSRO1|FSO01",
+        "해회혼합형": "FM001|FMA01|FMAD1|FMS01|FMB01|FMO01",
+        # "해외채권형": "FB001|FBG01|FBGB1|FBGH1|FBR01|FBRM1|FBRP1|FBRN1|FBRS1|FBRU1|FBO01"
+    }
+```
+- output : `펀드리스트_{~~형}.csv` & `fund_products` 테이블에 저장
+  ```csv
+    'fund_code', 'fund_name', 'std_price', 'set_date', 'fund_type', 'fund_type_detail', 'set_amount', 'risk_grade', 'risk_grade_txt', 'company_name'
+    펀드코드, 펀드이름, 기준가, 설정일, 펀드유형, 펀드유형세부, 펀드규모(설정액), 위험등급(숫자), 위험등급(텍스트), 운용사
+    
+  ```
+
+3. fund_porfolio.py 실행
+- 기능 : DB에 저장된 펀드 코드들의 자산구성, 보유채권, 보유주식을 수집하여 DB에 업로드합니다.  
+- 특이사항 : 데이터 양이 많아 아래 `UNIT` 변수를 통해 끊어서 크롤링하였습니다. 
+```python
+UNIT = 2000
+# ...
+for fund_code in tqdm(fund_code_list[:UNIT]):
+    #...
+```
+
+- output : 
+  - 자산 구성 : `fund_assets` 테이블에 저장 
+     ```csv
+    'fund_code', 'stock', 'stock_foreign', 'bond', 'bond_foreign', 'investment', 'etc'    
+    펀드코드, 국내주식, 해외주식, 국내채권, 해외채권, 수익증권, 기타
+     ```
+  - 보유 주식 : `fund_stocks` 테이블에 저장 
+     ```csv
+    'fund_code', 'stock_name', 'size', 'style', 'rate'
+     펀드코드, 주식명, 주식구분_규모, 주식구분_스타일, 비중
+     ```
+  - 보유 채권 : `fund_bonds` 테이블에 저장 
+     ```csv
+     'fund_code', 'bond_name', 'expire_date', 'duration', 'credit', 'rate'
+     펀드코드, 채권명, 만기일, 듀레이션, 신용등급, 비중
+     ```

--- a/fundguide/fund_porfolio.py
+++ b/fundguide/fund_porfolio.py
@@ -1,0 +1,178 @@
+from utils.db import connect_db
+from utils.converter import to_str, decode_html
+from utils.date import get_date_sdt
+import requests
+import pandas as pd
+from tqdm import tqdm
+import sqlalchemy
+from sqlalchemy import text
+
+db_connection, conn = connect_db()
+
+
+def get_fund_portfolio(fund_code):
+    url = f"https://www.fundguide.net/Api/Fund/GetFundPortfolio?fund_cd={fund_code}"
+    response = requests.get(url)
+    if response.status_code == 200:
+        data = response.json()["Data"]
+        fund_asset = []
+        fund_stock_item = []
+        fund_bond_item = []
+
+        if len(data[0]) > 0:  # 자산 구성
+            fund_asset = get_fund_asset(fund_code, data[0][0])
+        if len(data[2]) > 0:  # 주식
+            fund_stock_item = get_fund_stock_item(fund_code, data[2])
+        if len(data[6]) > 0:  # 채권
+            fund_bond_item = get_fund_bond_item(fund_code, data[6])
+
+        return fund_asset, fund_stock_item, fund_bond_item
+
+
+def get_fund_asset(fund_code, data):
+    stock = data["STOCK_RT"]
+    stock_foreign = data["STOCK_FRG_RT"]
+    bond = data["BOND_RT"]
+    bond_foreign = data["BOND_FRG_RT"]
+    investment = data["INVEST_RT"]
+    etc = data["ETC_RT"]
+
+    return [fund_code, stock, stock_foreign, bond, bond_foreign, investment, etc]
+
+
+def get_fund_stock_item(fund_code, data):
+    stock_items = []
+    for d in data:
+        stock_name = d["ITEM_NM"]
+        size = to_str(d["STK_SIZE_GB"])
+        style = to_str(d["STK_VAL_GB"])
+        rate = d["ASSET_C_RT"]
+
+        stock_items.append([fund_code, stock_name, size, style, rate])
+    return stock_items
+
+
+def get_fund_bond_item(fund_code, data):
+    bond_items = []
+    for d in data:
+        bond_name = decode_html(d["ITEM_NM"])
+        expire_date = d["EXP_DT"]
+        duration = d["ADJ_DUR"]
+        credit = d["CREDIT_NM"]
+        rate = d["ASSET_C_RT"]
+
+        bond_items.append([fund_code, bond_name, expire_date, duration, credit, rate])
+    return bond_items
+
+
+def get_fund_code_from_db():
+    # fund_products 에는 존재하지만 fund_assets에는 존재하지 않는 펀드 코드들
+    sql = """ 
+        SELECT fp.fund_code
+        FROM fund_products fp
+        LEFT JOIN fund_assets fa ON fp.fund_code = fa.fund_code
+        WHERE fa.fund_code IS NULL
+        ORDER BY fund_code
+        """
+    df = pd.read_sql(sql, con=db_connection)
+    fund_code_list = df['fund_code'].tolist()
+    return fund_code_list
+
+
+def upload_fund_asset_db(fund_asset_list):
+    print(">> 자산 구성 DB 업로드..")
+    df = pd.DataFrame(fund_asset_list,
+                      columns=['fund_code', 'stock', 'stock_foreign', 'bond', 'bond_foreign', 'investment', 'etc'])
+
+    # TODO: 펀드 자산 구성이 바뀌는지 확인해보고 있으면 update 없으면 insert로 변경하기
+    # 데이터베이스에 데이터 삽입
+    for index, row in df.iterrows():
+        insert_query = text("""
+            INSERT IGNORE INTO fund_assets (fund_code, stock, stock_foreign, bond, bond_foreign, investment, etc)
+            VALUES (:fund_code, :stock, :stock_foreign, :bond, :bond_foreign, :investment, :etc);
+            """)
+        conn.execute(insert_query, {'fund_code': row['fund_code'], 'stock': row['stock'],
+                                    'stock_foreign': row['stock_foreign'], 'bond': row['bond'],
+                                    'bond_foreign': row['bond_foreign'], 'investment': row['investment'],
+                                    'etc': row['etc']})
+        conn.commit()
+
+    print(">> 자산 구성 DB 업로드 완료")
+
+
+def upload_fund_stocks_db(fund_stock_item_list):
+    print(">> 펀드 보유 주식 DB 업로드..")
+    df = pd.DataFrame(fund_stock_item_list, columns=['fund_code', 'stock_name', 'size', 'style', 'rate'])
+    dtypesql = {
+        'fund_code': sqlalchemy.types.VARCHAR(255),
+        'stock_name': sqlalchemy.types.VARCHAR(255),
+        'size': sqlalchemy.types.VARCHAR(255),
+        'style': sqlalchemy.types.VARCHAR(255),
+        'rate': sqlalchemy.types.Float,
+    }
+    df.to_sql(name='fund_stocks', con=db_connection, if_exists='append', index=False, dtype=dtypesql)
+    print(">> 펀드 보유 주식 DB 업로드 완료")
+
+
+def upload_fund_bonds_db(fund_bond_item_list):
+    print(">> 펀드 보유 채권 DB 업로드 ...")
+    df = pd.DataFrame(fund_bond_item_list,
+                      columns=['fund_code', 'bond_name', 'expire_date', 'duration', 'credit', 'rate'])
+    dtypesql = {
+        'fund_code': sqlalchemy.types.VARCHAR(255),
+        'bond_name': sqlalchemy.types.VARCHAR(255),
+        'expire_date': sqlalchemy.types.Date,
+        'duration': sqlalchemy.types.Float,
+        'credit': sqlalchemy.types.VARCHAR(255),
+        'rate': sqlalchemy.types.Float,
+    }
+    df.to_sql(name='fund_bonds', con=db_connection, if_exists='append', index=False, dtype=dtypesql)
+    print(">> 펀드 보유 채권 DB 업로드 완료")
+
+
+def get_upload_fund_code_list() -> list[str]:
+    sql = """ 
+            SELECT fp.fund_code
+            FROM fund_products fp
+            LEFT JOIN fund_assets fa ON fp.fund_code = fa.fund_code
+            WHERE fa.fund_code IS NULL
+            ORDER BY fund_code
+            """
+    df = pd.read_sql(sql, con=db_connection)
+    return df['fund_code'].tolist()
+
+
+if __name__ == "__main__":
+    fund_code_list = get_fund_code_from_db()
+    UNIT = 2000 # 양이 많아서 끊어서 크롤링
+    fund_asset_list = []
+    fund_stock_item_list = []
+    fund_bond_item_list = []
+
+    fail_code_list = []
+
+    for fund_code in tqdm(fund_code_list[:UNIT]):
+        try:
+            fund_asset, fund_stock_item, fund_bond_item = get_fund_portfolio(fund_code)
+            fund_asset_list.append(fund_asset)
+            fund_stock_item_list.extend(fund_stock_item)
+            fund_bond_item_list.extend(fund_bond_item)
+        except Exception as e:
+            print(f"크롤링 실패 : {fund_code}")
+            print(e)
+            fail_code_list.append(fund_code)
+
+    try:
+        upload_fund_asset_db(fund_asset_list)
+        upload_fund_bonds_db(fund_bond_item_list)
+        upload_fund_stocks_db(fund_stock_item_list)
+    except Exception as e:
+        print(f"DB 업로드 실패 : {fund_code}")
+        print(e)
+        fail_code_list.append(fund_code)
+
+    if fail_code_list:
+        # DataFrame 생성
+        df = pd.DataFrame(fail_code_list, columns=['fund_code'])
+        # 파일로 저장
+        df.to_csv(f'fail_code_list_{get_date_sdt()}.csv', index=False)

--- a/fundguide/fund_porfolio.py
+++ b/fundguide/fund_porfolio.py
@@ -75,8 +75,7 @@ def get_fund_code_from_db():
         ORDER BY fund_code
         """
     df = pd.read_sql(sql, con=db_connection)
-    fund_code_list = df['fund_code'].tolist()
-    return fund_code_list
+    return df['fund_code'].tolist()
 
 
 def upload_fund_asset_db(fund_asset_list):
@@ -128,18 +127,6 @@ def upload_fund_bonds_db(fund_bond_item_list):
     }
     df.to_sql(name='fund_bonds', con=db_connection, if_exists='append', index=False, dtype=dtypesql)
     print(">> 펀드 보유 채권 DB 업로드 완료")
-
-
-def get_upload_fund_code_list() -> list[str]:
-    sql = """ 
-            SELECT fp.fund_code
-            FROM fund_products fp
-            LEFT JOIN fund_assets fa ON fp.fund_code = fa.fund_code
-            WHERE fa.fund_code IS NULL
-            ORDER BY fund_code
-            """
-    df = pd.read_sql(sql, con=db_connection)
-    return df['fund_code'].tolist()
 
 
 if __name__ == "__main__":

--- a/fundguide/fundlist.py
+++ b/fundguide/fundlist.py
@@ -80,19 +80,19 @@ def upload_funds(name, sel_peer):
         if fund_info:
             all_items.append(fund_info)
 
-    df = pd.DataFrame(all_items, columns=['code', 'name', 'std_price', 'set_date', 'type', 'type_detail', 'set_amount', 'risk_grade', 'risk_grade_txt', 'company_name'])
+    df = pd.DataFrame(all_items, columns=['fund_code', 'fund_name', 'std_price', 'set_date', 'fund_type', 'fund_type_detail', 'set_amount', 'risk_grade', 'risk_grade_txt', 'company_name'])
 
     # csv로 저장
     df.to_csv(f'펀드리스트_{name}.csv', index=False)
 
     db_connection = connect_db()
     dtypesql = {
-        'code': sqlalchemy.types.VARCHAR(255),
-        'name': sqlalchemy.types.VARCHAR(255),
+        'fund_code': sqlalchemy.types.VARCHAR(255),
+        'fund_name': sqlalchemy.types.VARCHAR(255),
         'std_price': sqlalchemy.types.Float,
         'set_date': sqlalchemy.types.Date,
-        'type': sqlalchemy.types.VARCHAR(255),
-        'type_detail': sqlalchemy.types.VARCHAR(255),
+        'fund_type': sqlalchemy.types.VARCHAR(255),
+        'fund_type_detail': sqlalchemy.types.VARCHAR(255),
         'set_amount': sqlalchemy.types.Integer,
         'risk_grade': sqlalchemy.types.Integer,
         'risk_grade_txt': sqlalchemy.types.VARCHAR(255),

--- a/fundguide/fundlist.py
+++ b/fundguide/fundlist.py
@@ -1,0 +1,116 @@
+from utils.db import connect_db
+from utils.converter import to_int
+import requests
+import pandas as pd
+from tqdm import tqdm
+import sqlalchemy
+
+def get_fund_info(fund_code):
+    url = f"https://www.fundguide.net/Api/Fund/GetFundInfo?fund_cd={fund_code}"
+    response = requests.get(url)
+    if response.status_code == 200:
+        data_list = response.json()['Data'][0]
+        for data in data_list:
+            code = data["FUND_CD"]
+            name = data["FUND_NM"]
+            std_price = data["STD_PRC"].replace(",", "") # 기준가
+            set_date = data["SET_DT"] # 설정일
+            type = data["PEER_CD_NM"] # 펀드
+            type_detail = data["PEER_CD_L_NM"]
+            set_amount = data["SET_AMT"]
+            risk_grade = data["RISK_GRADE"]
+            risk_grade_txt = data["RISK_GRADE_TXT"]
+            company_name = data["CO_NM"]
+
+            return [code, name, std_price, set_date, type, type_detail, set_amount, risk_grade, risk_grade_txt, company_name]
+
+
+def get_fund_code_list(sel_peer, page=1, row_cnt=10):
+    url = f'https://www.fundguide.net/Api/Fund/GetFundList'
+    params = {
+        "selPeer": sel_peer,
+        "selPeerDepth": "1|2|3|3|3|3|3|2|3|3|3|3",
+        "listCondFr": "0.00|0.00",
+        "listCondNm": "수탁고|총보수율",
+        "listCondTo": "120,375.66|73.58",
+        "listCondOption": "1|1",
+        "listCondGroup": "C|B",
+        "listCondSeq": "2|1",
+        "sort_col": "RT_1Y",
+        "ord_gb": "DESC",
+        "page_no": page,
+        "row_cnt": row_cnt,
+    }
+
+    response = requests.get(url, params=params)
+    if response.status_code == 200:
+        data_list = response.json()['Data'][0]
+        total = to_int(data_list[0]["ROW_CNT"])
+        funds = [data["FUND_CD"] for data in data_list]
+        return funds, total
+    else:
+        print("연결 실패")
+        return [], 0
+
+
+def calculate_total_pages(total_count, row_cnt):
+    if row_cnt == 0:
+        return 0
+    return (total_count + row_cnt - 1) // row_cnt
+
+
+def upload_funds(name, sel_peer):
+    page = 1
+    row_cnt = 50
+    _, total_count = get_fund_code_list(sel_peer, page, row_cnt)
+    total_pages = calculate_total_pages(total_count, row_cnt)
+    fund_codes = []
+    print("펀드 코드 수집 시작 >> ")
+    for page in tqdm(range(1, total_pages + 1)):
+        code_list, _ = get_fund_code_list(sel_peer, page, row_cnt)
+        fund_codes.extend(code_list)
+
+    print(f"수집한 코드 개수: {len(fund_codes)} / {total_count}")
+    fund_codes = list(set(fund_codes)) # 중복이 있다면 제거
+    print(f"중복 제거 후: {len(fund_codes)}개")
+    print("펀드 상세 정보 수집 시작 >> ")
+    all_items = []
+    for fund_code in tqdm(fund_codes):
+        fund_info = get_fund_info(fund_code)
+        if fund_info:
+            all_items.append(fund_info)
+
+    df = pd.DataFrame(all_items, columns=['code', 'name', 'std_price', 'set_date', 'type', 'type_detail', 'set_amount', 'risk_grade', 'risk_grade_txt', 'company_name'])
+
+    # csv로 저장
+    df.to_csv(f'펀드리스트_{name}.csv', index=False)
+
+    db_connection = connect_db()
+    dtypesql = {
+        'code': sqlalchemy.types.VARCHAR(255),
+        'name': sqlalchemy.types.VARCHAR(255),
+        'std_price': sqlalchemy.types.Float,
+        'set_date': sqlalchemy.types.Date,
+        'type': sqlalchemy.types.VARCHAR(255),
+        'type_detail': sqlalchemy.types.VARCHAR(255),
+        'set_amount': sqlalchemy.types.Integer,
+        'risk_grade': sqlalchemy.types.Integer,
+        'risk_grade_txt': sqlalchemy.types.VARCHAR(255),
+        'company_name': sqlalchemy.types.VARCHAR(255)
+    }
+
+    df.to_sql(name='fund_products', con=db_connection, if_exists='append', index=False, dtype=dtypesql)
+if __name__ == "__main__":
+
+    sel_peers = {
+        # "국내주식형": "HS001|HSA01|HSAG1|HSAM1|HSAD1|HSAS1|HSAT1|HSP01|HSPP1|HSPX1|HSPS1|HSPO1",
+        # "국내혼합형": "HM001|HMA01|HMS01|HMB01|HMBM1|HMBA1|HMBH1",
+        # "국내채권형": "HB001|HBG01|HBC01|HBB01|HBBO1|HBBS1|HBH01",
+        # "해외주식형": "FS001|FSC01|FSCJ1|FSCC1|FSCI1|FSCV1|FSCB1|FSCR1|FSCO1|FSS01|FSSE1|FSSM1|FSSH1|FSSF1|FSSI1|FSSP1|FSSC1|FSSN1|FSSO1|FSR01|FSRG1|FSRD1|FSRM1|FSRU1|FSRE1|FSRN1|FSRS1|FSRP1|FSRX1|FSRA1|FSRI1|FSRO1|FSO01",
+        "해회혼합형": "FM001|FMA01|FMAD1|FMS01|FMB01|FMO01",
+        "해외채권형": "FB001|FBG01|FBGB1|FBGH1|FBR01|FBRM1|FBRP1|FBRN1|FBRS1|FBRU1|FBO01"
+    }
+
+    for key, value in sel_peers.items():
+        print(f"[{key}] 데이터 수집")
+        upload_funds(key, value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ requests
 python-dotenv
 tqdm
 openpyxl
+SQLAlchemy
+PyMySQL

--- a/utils/converter.py
+++ b/utils/converter.py
@@ -1,0 +1,22 @@
+import html
+
+
+def to_int(str):
+    if str is None or str == '':
+        return
+    return int(str.replace(",", ""))
+
+
+def to_str(str):
+    if str is None or str == '':
+        return
+    return str
+
+
+def decode_html(str):
+    return html.unescape(str)
+
+
+if __name__ == "__main__":
+    print(decode_html("HAOHUA 4 7&#47;8 03&#47;14&#47;25"))
+    print("수산금융채권(신특)04-03이표12-07호")

--- a/utils/db.py
+++ b/utils/db.py
@@ -15,8 +15,8 @@ def connect_db():
     # sql로 저장
     db_connection_str = f'mysql+pymysql://{username}:{password}@{hostname}:3306/{schema}'
     db_connection = create_engine(db_connection_str)
-    db_connection.connect()
-    return db_connection
+    conn = db_connection.connect()
+    return db_connection, conn
 
 if __name__ == "__main__":
     connect_db()


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 펀드가이드 펀드 데이터 크롤러
   - 펀드 리스트 (csv 파일, db 저장)
   - 펀드 자산구성, 보유채권, 보유주식(db 저장)
<br/>

## 🔥 트러블 슈팅 (선택) 
- 펀드리스트로 총 수집한 데이터가 16000개 가량의 행이었습니다.
각 펀드의 상세 정보를 수집하는 데 총 5시간이 걸려, 이를 줄이기 위해 여러 대의 컴퓨터에서 크롤링을 작업하기 위한 변경 사항들이 있었습니다. 


먼저 특정 단위로 끊어서 크롤링을 진행하였습니다.     
동시에 진행함에 따라 중복된 데이터를 수집하지 않게 하기 위해 앞에서부터 2000개, 뒤에서부터 2000개 이런 식으로 나누었습니다. 
```python
UNIT = 2000 # 양이 많아서 끊어서 크롤링
    for fund_code in tqdm(fund_code_list[:UNIT]): # 컴퓨터1
    for fund_code in tqdm(fund_code_list[-UNIT:]): # 컴퓨터2
     ...
```

이미 수집한 데이터를 또다시 수집하지 않기 위해 
본래 fund_products 모든 행의 fund_code를 가져오는 SQL문을 아래와 같이 수정하여,
fund_products 에는 존재하지만 fund_assets에는 존재하지 않는 펀드 코드들만 데이터 수집을 진행하도록 변경하였습니다.  
(before)
```sql
        SELECT fp.fund_code
        FROM fund_products fp
```
(after)
```sql
        SELECT fp.fund_code
        FROM fund_products fp
        LEFT JOIN fund_assets fa ON fp.fund_code = fa.fund_code
        WHERE fa.fund_code IS NULL
        ORDER BY fund_code
```

- fund_assets 테이블의 경우 fund_code가 unique한 속성을 가지고 있습니다. 
데이터 업로드 시 INSERT IGNORE INTO를 통해 이미 업로드된 데이터라면 무시하도록 처리하였습니다.  
```sql
INSERT IGNORE INTO fund_assets (fund_code, stock, stock_foreign, bond, bond_foreign, investment, etc)
VALUES (:fund_code, :stock, :stock_foreign, :bond, :bond_foreign, :investment, :etc);
```

- 중간에 크롤링에 실패하는 펀드들은 try except로 처리하였습니다. 로그를 찍은 후 해당 펀드들은 fail_code_list에 추가 후 별도 확인을 거치는 작업을 진행하였습니다. 
```python
    if fail_code_list:
        # DataFrame 생성
        df = pd.DataFrame(fail_code_list, columns=['fund_code'])
        # 파일로 저장
        df.to_csv(f'fail_code_list_{get_date_sdt()}.csv', index=False)

```
대부분 실패 원인은 주로 사이트에 내려간 펀드들로 사이트에 검색해도 나오지 않는 펀드들이었습니다. 
데이터 수집 완료 후 DB에서 fund_products 테이블에 존재하지만 fund_assets에는 존재하지 않는 코드를 제거하는 SQL문을 실행할 예정입니다.
<br/>

## 📚 기타
- 펀드 자산 구성이 업데이트되는지 확인해보고 있으면 update 없으면 insert로 변경하는 방안을 고려중에 있습니다.

<br/> 

## 🌱 관련 이슈 (필수)
- close #2  

<br/> 
